### PR TITLE
v2.16.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.16.106](https://github.com/bundled-es-modules/pdfjs-dist/releases/tag/v2.16.106)
+
+- Equivalent to `v2.16.105`, corrects a problem w/ that relase:  the `web/` folder is missing! The intent of this release is to _not_ cause breakages for consumers who may start receiving the incorrectly-published `v2.16.105` release. Oops!
+
+## [v2.16.105](https://github.com/bundled-es-modules/pdfjs-dist/releases/tag/v2.16.105)
+
+- Accidentally published a bundle which was missing some files
+
 ## [v2.16.105-alpha.1](https://github.com/bundled-es-modules/pdfjs-dist/releases/tag/v2.16.105-alpha.1)
 
 - Ugraded to `pdfjs-dist` [v2.16.105](https://github.com/mozilla/pdf.js/releases/tag/v2.16.105)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bundled-es-modules/pdfjs-dist",
-  "version": "2.16.105-alpha.1",
+  "version": "2.16.106",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bundled-es-modules/pdfjs-dist",
-      "version": "2.16.105-alpha.1",
+      "version": "2.16.106",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "@bundled-es-modules/pdfjs-dist",
-  "version": "2.16.105",
+  "version": "2.16.106",
   "description": "mirror of pdfjs-dist, bundled and exposed as ES module",
   "author": "Rob Resendez (resendez.java@gmail.com)",
   "type": "module",
   "module": "build/pdf.js",
   "main": "build/pdf.js",
+  "files": [
+    "build/",
+    "src/",
+    "web/"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Was attempting to publish a non-pre-release tag of `v2.16.105` to npm because `alpha.2` has been out there for quite some time and I was going to create a new major release.

Accidentally published w/o transmitting the required `web/` folder (which was not sent because it's in .gitignore)